### PR TITLE
Slight Weapon Rebalancing

### DIFF
--- a/src/main/java/drzhark/mocreatures/init/MoCItems.java
+++ b/src/main/java/drzhark/mocreatures/init/MoCItems.java
@@ -77,7 +77,7 @@ public class MoCItems {
     public static final MoCItemSword bo = new MoCItemSword("bo", Item.ToolMaterial.IRON);
     public static final MoCItemSword katana = new MoCItemSword("katana", Item.ToolMaterial.IRON);
     public static final MoCItemSword sharksword = new MoCItemSword("sharksword", Item.ToolMaterial.IRON);
-    public static final MoCItemSword silversword = new MoCItemSword("silversword", EnumHelper.addToolMaterial("SILVER", 0, 250, 6.0F, 4, 15));
+    public static final MoCItemSword silversword = new MoCItemSword("silversword", EnumHelper.addToolMaterial("SILVER", 0, 177, 6.0F, 1.5F, 19));
     public static final MoCItemSword scorpSwordCave = new MoCItemSword("scorpswordcave", ToolMaterial.IRON, 4, false);
     public static final MoCItemSword scorpSwordFrost = new MoCItemSword("scorpswordfrost", ToolMaterial.IRON, 2, false);
     public static final MoCItemSword scorpSwordNether = new MoCItemSword("scorpswordnether", ToolMaterial.IRON, 3, false);
@@ -86,9 +86,9 @@ public class MoCItems {
     public static final MoCItemWeapon scorpStingFrost = new MoCItemWeapon("scorpstingfrost", ToolMaterial.GOLD, 2, true);
     public static final MoCItemWeapon scorpStingNether = new MoCItemWeapon("scorpstingnether", ToolMaterial.GOLD, 3, true);
     public static final MoCItemWeapon scorpStingDirt = new MoCItemWeapon("scorpstingdirt", ToolMaterial.GOLD, 1, true);
-    public static final MoCItemWeapon tusksWood = new MoCItemWeapon("tuskswood", ToolMaterial.WOOD);
-    public static final MoCItemWeapon tusksIron = new MoCItemWeapon("tusksiron", ToolMaterial.IRON);
-    public static final MoCItemWeapon tusksDiamond = new MoCItemWeapon("tusksdiamond", ToolMaterial.DIAMOND);
+    public static final MoCItem tusksWood = new MoCItem("tuskswood");
+    public static final MoCItem tusksIron = new MoCItem("tusksiron");
+    public static final MoCItem tusksDiamond = new MoCItem("tusksdiamond");
     public static final MoCItem elephantHarness = new MoCItem("elephantharness");
     public static final MoCItem elephantChest = new MoCItem("elephantchest");
     public static final MoCItem elephantGarment = new MoCItem("elephantgarment");

--- a/src/main/java/drzhark/mocreatures/init/MoCItems.java
+++ b/src/main/java/drzhark/mocreatures/init/MoCItems.java
@@ -77,7 +77,7 @@ public class MoCItems {
     public static final MoCItemSword bo = new MoCItemSword("bo", Item.ToolMaterial.IRON);
     public static final MoCItemSword katana = new MoCItemSword("katana", Item.ToolMaterial.IRON);
     public static final MoCItemSword sharksword = new MoCItemSword("sharksword", Item.ToolMaterial.IRON);
-    public static final MoCItemSword silversword = new MoCItemSword("silversword", EnumHelper.addToolMaterial("SILVER", 0, 177, 6.0F, 1.5F, 19));
+    public static final MoCItemSword silversword = new MoCItemSword("silversword", EnumHelper.addToolMaterial("SILVER", 0, 224, 6.0F, 3, 19));
     public static final MoCItemSword scorpSwordCave = new MoCItemSword("scorpswordcave", ToolMaterial.IRON, 4, false);
     public static final MoCItemSword scorpSwordFrost = new MoCItemSword("scorpswordfrost", ToolMaterial.IRON, 2, false);
     public static final MoCItemSword scorpSwordNether = new MoCItemSword("scorpswordnether", ToolMaterial.IRON, 3, false);

--- a/src/main/java/drzhark/mocreatures/item/MoCItemSword.java
+++ b/src/main/java/drzhark/mocreatures/item/MoCItemSword.java
@@ -59,8 +59,8 @@ public class MoCItemSword extends ItemSword {
             case 3: //fire
                 target.setFire(10);
                 break;
-            case 4: //confusion
-                target.addPotionEffect(new PotionEffect(MobEffects.NAUSEA, potionTime, 0));
+            case 4: //weakness
+                target.addPotionEffect(new PotionEffect(MobEffects.WEAKNESS, potionTime, 0));
                 break;
             case 5: //blindness
                 target.addPotionEffect(new PotionEffect(MobEffects.BLINDNESS, potionTime, 0));

--- a/src/main/java/drzhark/mocreatures/item/MoCItemWeapon.java
+++ b/src/main/java/drzhark/mocreatures/item/MoCItemWeapon.java
@@ -39,7 +39,7 @@ public class MoCItemWeapon extends MoCItem {
         this.material = par2ToolMaterial;
         this.maxStackSize = 1;
         this.setMaxDamage(par2ToolMaterial.getMaxUses());
-        this.attackDamage = 2.5F + par2ToolMaterial.getAttackDamage();
+        this.attackDamage = 3F + par2ToolMaterial.getAttackDamage();
     }
 
     /**

--- a/src/main/java/drzhark/mocreatures/item/MoCItemWeapon.java
+++ b/src/main/java/drzhark/mocreatures/item/MoCItemWeapon.java
@@ -39,12 +39,12 @@ public class MoCItemWeapon extends MoCItem {
         this.material = par2ToolMaterial;
         this.maxStackSize = 1;
         this.setMaxDamage(par2ToolMaterial.getMaxUses());
-        this.attackDamage = 4F + par2ToolMaterial.getAttackDamage();
+        this.attackDamage = 2.5F + par2ToolMaterial.getAttackDamage();
     }
 
     /**
      * @param damageType 0 = default, 1 = poison, 2 = slow down, 3 = fire, 4 =
-     *                   confusion, 5 = blindness
+     *                   weakness, 5 = blindness
      */
     public MoCItemWeapon(String name, ToolMaterial par2ToolMaterial, int damageType, boolean fragile) {
         this(name, par2ToolMaterial);
@@ -79,7 +79,7 @@ public class MoCItemWeapon extends MoCItem {
     public boolean hitEntity(ItemStack par1ItemStack, EntityLivingBase target, EntityLivingBase attacker) {
         int i = 1;
         if (this.breakable) {
-            i = 10;
+            i = 5;
         }
         par1ItemStack.damageItem(i, attacker);
         int potionTime = 100;
@@ -93,8 +93,8 @@ public class MoCItemWeapon extends MoCItem {
             case 3: //fire
                 target.setFire(10);
                 break;
-            case 4: //confusion
-                target.addPotionEffect(new PotionEffect(MobEffects.NAUSEA, potionTime, 0));
+            case 4: //weakness
+                target.addPotionEffect(new PotionEffect(MobEffects.WEAKNESS, potionTime, 0));
                 break;
             case 5: //blindness
                 target.addPotionEffect(new PotionEffect(MobEffects.BLINDNESS, potionTime, 0));


### PR DESCRIPTION
Nothing too fancy yet but it should address #11 a bit. This rebalances the silver sword and scorpion stings while also removing all damage from tusks. Feel free to adjust anything if they're a bit much!

**Cave Scorpion Sting/Sting Blade:**
Now deals Weakness instead of Nausea, it doesn't seem fair for it to deal an effect that only affects players while the other variants have more useful effects against mobs.

**Scorpion Stings:**
Slightly nerfed the damage due to stings having no cooldown, also now lowers 5 durability per hit instead of 10. It is still very useful as an emergency weapon with very low durability.
Damage: 5 > 3.5

**Silver Sword:**
This brings the damage down from diamond but makes up for it with higher enchantability closer to gold and still being an effective werewolf weapon.
Damage: 8 > 5.5
Durability: 250 > 177
Enchantability: 15 > 19