### PR TITLE
Fix Egg Drops for `Wyvern` and `Fishy`

### DIFF
--- a/src/main/java/drzhark/mocreatures/entity/MoCEntityAnimal.java
+++ b/src/main/java/drzhark/mocreatures/entity/MoCEntityAnimal.java
@@ -332,6 +332,9 @@ public abstract class MoCEntityAnimal extends EntityAnimal implements IMoCEntity
         return isInsideOfMaterial(Material.WATER);
     }
 
+    // used to drop eggs in a legacy fashion
+    public void dropLegacyEgg() {
+    }
     //used to drop armor, inventory, saddles, etc.
     public void dropMyStuff() {
     }
@@ -785,6 +788,7 @@ public abstract class MoCEntityAnimal extends EntityAnimal implements IMoCEntity
     public void onDeath(DamageSource damagesource) {
         if (!this.world.isRemote) {
             dropMyStuff();
+            dropLegacyEgg();
         }
 
         super.onDeath(damagesource);

--- a/src/main/java/drzhark/mocreatures/entity/MoCEntityAquatic.java
+++ b/src/main/java/drzhark/mocreatures/entity/MoCEntityAquatic.java
@@ -562,6 +562,9 @@ public abstract class MoCEntityAquatic extends EntityCreature implements IMoCEnt
         return (this instanceof IMoCTameable) && getIsTamed();
     }
 
+    // used to drop eggs in a legacy fashion
+    public void dropLegacyEgg() {
+    }
     protected void dropMyStuff() {
     }
 
@@ -622,6 +625,15 @@ public abstract class MoCEntityAquatic extends EntityCreature implements IMoCEnt
         return 0F;
     }
 
+    @Override
+    public void onDeath(DamageSource damagesource) {
+        if (!this.world.isRemote) {
+            dropMyStuff();
+            dropLegacyEgg();
+        }
+
+        super.onDeath(damagesource);
+    }
     @Override
     public boolean isNotScared() {
         return false;

--- a/src/main/java/drzhark/mocreatures/entity/aquatic/MoCEntityFishy.java
+++ b/src/main/java/drzhark/mocreatures/entity/aquatic/MoCEntityFishy.java
@@ -107,14 +107,10 @@ public class MoCEntityFishy extends MoCEntityTameableAquatic {
     @Override
     protected void dropFewItems(boolean flag, int x) {
         int i = this.rand.nextInt(100);
-        if (i < 70) {
-            //entityDropItem(new ItemStack(Items.FISH, 1, 0), 0.0F);
-        } else {
+        if (i < 30) {
             int j = this.rand.nextInt(2);
-            for (int k = 0; k < j; k++) {
-                entityDropItem(new ItemStack(MoCItems.mocegg, 1, getType()), 0.0F);
-            }
-
+            System.out.println("FISHY: Type is "+getType()+j);
+            entityDropItem(new ItemStack(MoCItems.mocegg, j, getType()), 0.0F);
         }
     }
 

--- a/src/main/java/drzhark/mocreatures/entity/aquatic/MoCEntityFishy.java
+++ b/src/main/java/drzhark/mocreatures/entity/aquatic/MoCEntityFishy.java
@@ -109,7 +109,6 @@ public class MoCEntityFishy extends MoCEntityTameableAquatic {
         int i = this.rand.nextInt(100);
         if (i < 30) {
             int j = this.rand.nextInt(2);
-            System.out.println("FISHY: Type is "+getType()+"J is "+j);
             entityDropItem(new ItemStack(MoCItems.mocegg, j, getType()), 0.0F);
         }
     }

--- a/src/main/java/drzhark/mocreatures/entity/aquatic/MoCEntityFishy.java
+++ b/src/main/java/drzhark/mocreatures/entity/aquatic/MoCEntityFishy.java
@@ -105,7 +105,7 @@ public class MoCEntityFishy extends MoCEntityTameableAquatic {
     }
 
     @Override
-    protected void dropFewItems(boolean flag, int x) {
+    public void dropLegacyEgg() {
         int i = this.rand.nextInt(100);
         if (i < 30) {
             int j = this.rand.nextInt(2);

--- a/src/main/java/drzhark/mocreatures/entity/aquatic/MoCEntityFishy.java
+++ b/src/main/java/drzhark/mocreatures/entity/aquatic/MoCEntityFishy.java
@@ -109,7 +109,7 @@ public class MoCEntityFishy extends MoCEntityTameableAquatic {
         int i = this.rand.nextInt(100);
         if (i < 30) {
             int j = this.rand.nextInt(2);
-            System.out.println("FISHY: Type is "+getType()+j);
+            System.out.println("FISHY: Type is "+getType()+"J is "+j);
             entityDropItem(new ItemStack(MoCItems.mocegg, j, getType()), 0.0F);
         }
     }

--- a/src/main/java/drzhark/mocreatures/entity/hunter/MoCEntitySnake.java
+++ b/src/main/java/drzhark/mocreatures/entity/hunter/MoCEntitySnake.java
@@ -499,13 +499,10 @@ public class MoCEntitySnake extends MoCEntityTameableAnimal {
     }
 
     @Override
-    protected void dropFewItems(boolean flag, int x) {
+    public void dropLegacyEgg() {
         if (getAge() > 60) {
             int j = this.rand.nextInt(3);
-            for (int l = 0; l < j; l++) {
-
-                entityDropItem(new ItemStack(MoCItems.mocegg, 1, getType() + 20), 0.0F);
-            }
+            entityDropItem(new ItemStack(MoCItems.mocegg, j, getType() + 20), 0.0F);
         }
     }
 

--- a/src/main/java/drzhark/mocreatures/entity/neutral/MoCEntityWyvern.java
+++ b/src/main/java/drzhark/mocreatures/entity/neutral/MoCEntityWyvern.java
@@ -809,6 +809,7 @@ public class MoCEntityWyvern extends MoCEntityTameableAnimal {
     @Override
     protected void dropFewItems(boolean flag, int x) {
         int chance = MoCreatures.proxy.wyvernEggDropChance;
+        System.out.println("Chance: "+chance+" and type is "+getType());
         if (getType() == 5) { //mother wyverns drop eggs more frequently
             chance = MoCreatures.proxy.motherWyvernEggDropChance;
         }

--- a/src/main/java/drzhark/mocreatures/entity/neutral/MoCEntityWyvern.java
+++ b/src/main/java/drzhark/mocreatures/entity/neutral/MoCEntityWyvern.java
@@ -809,7 +809,6 @@ public class MoCEntityWyvern extends MoCEntityTameableAnimal {
     @Override
     public void dropLegacyEgg() {
         int chance = MoCreatures.proxy.wyvernEggDropChance;
-        System.out.println("Chance: "+chance+" and type is "+getType());
         if (getType() == 5) { //mother wyverns drop eggs more frequently
             chance = MoCreatures.proxy.motherWyvernEggDropChance;
         }

--- a/src/main/java/drzhark/mocreatures/entity/neutral/MoCEntityWyvern.java
+++ b/src/main/java/drzhark/mocreatures/entity/neutral/MoCEntityWyvern.java
@@ -807,7 +807,7 @@ public class MoCEntityWyvern extends MoCEntityTameableAnimal {
 
     // TODO: Remove this once wyvern eggs are overhauled
     @Override
-    protected void dropFewItems(boolean flag, int x) {
+    public void dropLegacyEgg() {
         int chance = MoCreatures.proxy.wyvernEggDropChance;
         System.out.println("Chance: "+chance+" and type is "+getType());
         if (getType() == 5) { //mother wyverns drop eggs more frequently


### PR DESCRIPTION
# Issue
- Relates to #80 
`dropFewItems` wasn't working for `Fishy` and `Wyvern`

# Changes
- For mobs that drop `mocegg` based on their type, use new function `dropLegacyEgg` which is more reliable than previous `dropFewItems` from Forge API. Includes `Wyvern`, `Fishy`, `Snake`.

# Test Cases
1. Kill `Wyvern`, observe dropped eggs of correct type (33% drop rate to be expected for non-mother wyverns)
2. Kill `Fishy` mobs, observe dropped eggs of correct type (30% expected drop rate)
3. Kill other `Aquatic` or `Animal` mobs to ensure their drops still work as expected.
4. Kill `Snake`, observe 0-2 eggs are dropped.

