### PR TITLE
96 - Tamed Mobs using `EntityAIHunt` should not initiate Player hunting behavior

### DIFF
--- a/src/main/java/drzhark/mocreatures/entity/MoCEntityAnimal.java
+++ b/src/main/java/drzhark/mocreatures/entity/MoCEntityAnimal.java
@@ -295,7 +295,8 @@ public abstract class MoCEntityAnimal extends EntityAnimal implements IMoCEntity
                 }
             }
 
-            if (MoCreatures.proxy.enableHunters && this.isReadyToHunt() && !this.getIsHunting() && this.rand.nextInt(500) == 0) {
+            // TODO: Revert after done testing
+            if (MoCreatures.proxy.enableHunters && this.isReadyToHunt() && !this.getIsHunting() && this.rand.nextInt(10) == 0) {
                 setIsHunting(true);
             }
 

--- a/src/main/java/drzhark/mocreatures/entity/MoCEntityAnimal.java
+++ b/src/main/java/drzhark/mocreatures/entity/MoCEntityAnimal.java
@@ -295,8 +295,7 @@ public abstract class MoCEntityAnimal extends EntityAnimal implements IMoCEntity
                 }
             }
 
-            // TODO: Revert after done testing
-            if (MoCreatures.proxy.enableHunters && this.isReadyToHunt() && !this.getIsHunting() && this.rand.nextInt(10) == 0) {
+            if (MoCreatures.proxy.enableHunters && this.isReadyToHunt() && !this.getIsHunting() && this.rand.nextInt(500) == 0) {
                 setIsHunting(true);
             }
 

--- a/src/main/java/drzhark/mocreatures/entity/ai/EntityAIHunt.java
+++ b/src/main/java/drzhark/mocreatures/entity/ai/EntityAIHunt.java
@@ -9,7 +9,6 @@ import drzhark.mocreatures.entity.tameable.MoCEntityTameableAnimal;
 import net.minecraft.entity.EntityCreature;
 import net.minecraft.entity.EntityLivingBase;
 import net.minecraft.entity.ai.EntityAINearestAttackableTarget;
-import java.util.UUID;
 
 public class EntityAIHunt<T extends EntityLivingBase> extends EntityAINearestAttackableTarget<T> {
 
@@ -32,8 +31,8 @@ public class EntityAIHunt<T extends EntityLivingBase> extends EntityAINearestAtt
     @Override
     public boolean shouldExecute() {
         // Big Cat fix
-        UUID hunterOwner = ((MoCEntityTameableAnimal)this.hunter).getOwnerId();
-        System.out.println("Check before hunting. hunterOwner is "+hunterOwner);
-        return hunterOwner == null && ((MoCEntityAnimal) this.hunter).getIsHunting() && super.shouldExecute();
+        boolean hunterHasOwner = ((MoCEntityTameableAnimal)this.hunter).getIsTamed();
+        System.out.println("Check before hunting. hunterHasOwner is "+hunterHasOwner);
+        return !hunterHasOwner && ((MoCEntityAnimal) this.hunter).getIsHunting() && super.shouldExecute();
     }
 }

--- a/src/main/java/drzhark/mocreatures/entity/ai/EntityAIHunt.java
+++ b/src/main/java/drzhark/mocreatures/entity/ai/EntityAIHunt.java
@@ -3,11 +3,23 @@
  */
 package drzhark.mocreatures.entity.ai;
 
+import com.google.common.base.Function;
 import com.google.common.base.Predicate;
 import drzhark.mocreatures.entity.MoCEntityAnimal;
+import drzhark.mocreatures.entity.tameable.MoCEntityTameableAnimal;
 import net.minecraft.entity.EntityCreature;
 import net.minecraft.entity.EntityLivingBase;
 import net.minecraft.entity.ai.EntityAINearestAttackableTarget;
+import net.minecraft.entity.monster.EntityCreeper;
+import net.minecraft.entity.monster.EntitySkeleton;
+import net.minecraft.entity.monster.EntityZombie;
+import net.minecraft.entity.player.EntityPlayer;
+import net.minecraft.init.Items;
+import net.minecraft.inventory.EntityEquipmentSlot;
+import net.minecraft.item.ItemStack;
+
+import javax.annotation.Nullable;
+import java.util.UUID;
 
 public class EntityAIHunt<T extends EntityLivingBase> extends EntityAINearestAttackableTarget<T> {
 
@@ -29,6 +41,9 @@ public class EntityAIHunt<T extends EntityLivingBase> extends EntityAINearestAtt
 
     @Override
     public boolean shouldExecute() {
-        return ((MoCEntityAnimal) this.hunter).getIsHunting() && super.shouldExecute();
+        // Big Cat fix
+        UUID hunterOwner = ((MoCEntityTameableAnimal)this.hunter).getOwnerId();
+        System.out.println("Check before hunting. hunterOwner is "+hunterOwner);
+        return hunterOwner == null && ((MoCEntityAnimal) this.hunter).getIsHunting() && super.shouldExecute();
     }
 }

--- a/src/main/java/drzhark/mocreatures/entity/ai/EntityAIHunt.java
+++ b/src/main/java/drzhark/mocreatures/entity/ai/EntityAIHunt.java
@@ -32,7 +32,6 @@ public class EntityAIHunt<T extends EntityLivingBase> extends EntityAINearestAtt
     public boolean shouldExecute() {
         // Big Cat fix
         boolean hunterHasOwner = ((MoCEntityTameableAnimal)this.hunter).getIsTamed();
-        System.out.println("Check before hunting. hunterHasOwner is "+hunterHasOwner);
         return !hunterHasOwner && ((MoCEntityAnimal) this.hunter).getIsHunting() && super.shouldExecute();
     }
 }

--- a/src/main/java/drzhark/mocreatures/entity/ai/EntityAIHunt.java
+++ b/src/main/java/drzhark/mocreatures/entity/ai/EntityAIHunt.java
@@ -3,22 +3,12 @@
  */
 package drzhark.mocreatures.entity.ai;
 
-import com.google.common.base.Function;
 import com.google.common.base.Predicate;
 import drzhark.mocreatures.entity.MoCEntityAnimal;
 import drzhark.mocreatures.entity.tameable.MoCEntityTameableAnimal;
 import net.minecraft.entity.EntityCreature;
 import net.minecraft.entity.EntityLivingBase;
 import net.minecraft.entity.ai.EntityAINearestAttackableTarget;
-import net.minecraft.entity.monster.EntityCreeper;
-import net.minecraft.entity.monster.EntitySkeleton;
-import net.minecraft.entity.monster.EntityZombie;
-import net.minecraft.entity.player.EntityPlayer;
-import net.minecraft.init.Items;
-import net.minecraft.inventory.EntityEquipmentSlot;
-import net.minecraft.item.ItemStack;
-
-import javax.annotation.Nullable;
 import java.util.UUID;
 
 public class EntityAIHunt<T extends EntityLivingBase> extends EntityAINearestAttackableTarget<T> {

--- a/src/main/java/drzhark/mocreatures/entity/ai/EntityAIHunt.java
+++ b/src/main/java/drzhark/mocreatures/entity/ai/EntityAIHunt.java
@@ -9,14 +9,17 @@ import drzhark.mocreatures.entity.tameable.MoCEntityTameableAnimal;
 import net.minecraft.entity.EntityCreature;
 import net.minecraft.entity.EntityLivingBase;
 import net.minecraft.entity.ai.EntityAINearestAttackableTarget;
+import net.minecraft.entity.player.EntityPlayer;
 
 public class EntityAIHunt<T extends EntityLivingBase> extends EntityAINearestAttackableTarget<T> {
 
     private final EntityCreature hunter;
+    private final Class<T> targetClass;
 
     public EntityAIHunt(EntityCreature entity, Class<T> classTarget, int chance, boolean checkSight, boolean onlyNearby, Predicate<EntityLivingBase> predicate) {
         super(entity, classTarget, chance, checkSight, onlyNearby, predicate);
         this.hunter = entity;
+        this.targetClass = classTarget;
     }
 
     public EntityAIHunt(EntityCreature entityCreature, Class<T> classTarget, boolean checkSight) {
@@ -30,8 +33,9 @@ public class EntityAIHunt<T extends EntityLivingBase> extends EntityAINearestAtt
 
     @Override
     public boolean shouldExecute() {
-        // Big Cat fix
+        // Conditions: Don't hunt when tamed and target entity is of class Player
         boolean hunterHasOwner = ((MoCEntityTameableAnimal)this.hunter).getIsTamed();
-        return !hunterHasOwner && ((MoCEntityAnimal) this.hunter).getIsHunting() && super.shouldExecute();
+        boolean hunterTargetsPlayers = EntityPlayer.class.isAssignableFrom(this.targetClass);
+        return (!hunterTargetsPlayers || !hunterHasOwner) && ((MoCEntityAnimal) this.hunter).getIsHunting() && super.shouldExecute();
     }
 }

--- a/src/main/java/drzhark/mocreatures/entity/aquatic/MoCEntityShark.java
+++ b/src/main/java/drzhark/mocreatures/entity/aquatic/MoCEntityShark.java
@@ -5,6 +5,7 @@ package drzhark.mocreatures.entity.aquatic;
 
 import drzhark.mocreatures.MoCreatures;
 import drzhark.mocreatures.entity.MoCEntityAquatic;
+import drzhark.mocreatures.entity.ai.EntityAIHunt;
 import drzhark.mocreatures.entity.ai.EntityAIWanderMoC2;
 import drzhark.mocreatures.entity.item.MoCEntityEgg;
 import drzhark.mocreatures.entity.passive.MoCEntityHorse;
@@ -44,7 +45,7 @@ public class MoCEntityShark extends MoCEntityTameableAquatic {
         this.tasks.addTask(2, new EntityAIAttackMelee(this, 1.0D, false));
         this.tasks.addTask(5, new EntityAIWanderMoC2(this, 1.0D, 30));
         this.targetTasks.addTask(1, new EntityAIHurtByTarget(this, false));
-        this.targetTasks.addTask(2, new EntityAINearestAttackableTarget<>(this, EntityPlayer.class, false));
+        this.targetTasks.addTask(3, new EntityAIHunt<>(this, EntityPlayer.class, false));
     }
 
     @Override


### PR DESCRIPTION
# Issue
- Related to #96 

# Description
Mobs using `EntityAIHunt` should not initiate Player hunting behavior once they are tamed.

This includes:
- Bear
- BigCat
- Crocodile
- Komodo
- Snake
- Shark