### PR TITLE
98 - AI Bugfix, Follow Owner

### DIFF
--- a/src/main/java/drzhark/mocreatures/entity/MoCEntityAnimal.java
+++ b/src/main/java/drzhark/mocreatures/entity/MoCEntityAnimal.java
@@ -298,7 +298,7 @@ public abstract class MoCEntityAnimal extends EntityAnimal implements IMoCEntity
 
             if (MoCreatures.proxy.enableHunters && this.isReadyToHunt() && !this.getIsHunting() && this.rand.nextInt(500) == 0) {
                 setIsHunting(true);
-            } else if (!this.getIsHunting() && this.isReadyToFollowOwnerPlayer() && !this.getIsFollowingOwnerPlayer() && this.rand.nextInt(150) == 0) {
+            } else if (!this.getIsHunting() && this.isReadyToFollowOwnerPlayer() && !this.getIsFollowingOwnerPlayer() && this.rand.nextInt(500) == 0) {
                 setIsFollowingOwnerPlayer(true);
             }
 

--- a/src/main/java/drzhark/mocreatures/entity/MoCEntityAnimal.java
+++ b/src/main/java/drzhark/mocreatures/entity/MoCEntityAnimal.java
@@ -61,6 +61,7 @@ public abstract class MoCEntityAnimal extends EntityAnimal implements IMoCEntity
     protected PathNavigate navigatorWater;
     protected PathNavigate navigatorFlyer;
     private int huntingCounter;
+    private int followPlayerCounter;
     private double divingDepth;
     private boolean randomAttributesUpdated; //used to update divingDepth on world load
 
@@ -297,10 +298,15 @@ public abstract class MoCEntityAnimal extends EntityAnimal implements IMoCEntity
 
             if (MoCreatures.proxy.enableHunters && this.isReadyToHunt() && !this.getIsHunting() && this.rand.nextInt(500) == 0) {
                 setIsHunting(true);
+            } else if (!this.getIsHunting() && this.isReadyToFollowOwnerPlayer() && !this.getIsFollowingOwnerPlayer() && this.rand.nextInt(60) == 0) {
+                setIsFollowingOwnerPlayer(true);
             }
 
             if (getIsHunting() && ++this.huntingCounter > 50) {
                 setIsHunting(false);
+            }
+            if (this.getIsFollowingOwnerPlayer() && ++this.followPlayerCounter > 50) {
+                setIsFollowingOwnerPlayer(false);
             }
 
             this.getNavigator().onUpdateNavigation();
@@ -874,6 +880,9 @@ public abstract class MoCEntityAnimal extends EntityAnimal implements IMoCEntity
     public boolean isReadyToHunt() {
         return false;
     }
+    public boolean isReadyToFollowOwnerPlayer() {
+        return false;
+    }
 
     @Override
     public boolean canBeLeashedTo(EntityPlayer player) {
@@ -902,6 +911,16 @@ public abstract class MoCEntityAnimal extends EntityAnimal implements IMoCEntity
             this.huntingCounter = this.rand.nextInt(30) + 1;
         } else {
             this.huntingCounter = 0;
+        }
+    }
+    public boolean getIsFollowingOwnerPlayer() {
+        return this.followPlayerCounter != 0;
+    }
+    public void setIsFollowingOwnerPlayer(boolean flag) {
+        if (flag) {
+            this.followPlayerCounter = this.rand.nextInt(30) + 1;
+        } else {
+            this.followPlayerCounter = 0;
         }
     }
 

--- a/src/main/java/drzhark/mocreatures/entity/MoCEntityAnimal.java
+++ b/src/main/java/drzhark/mocreatures/entity/MoCEntityAnimal.java
@@ -298,14 +298,14 @@ public abstract class MoCEntityAnimal extends EntityAnimal implements IMoCEntity
 
             if (MoCreatures.proxy.enableHunters && this.isReadyToHunt() && !this.getIsHunting() && this.rand.nextInt(500) == 0) {
                 setIsHunting(true);
-            } else if (!this.getIsHunting() && this.isReadyToFollowOwnerPlayer() && !this.getIsFollowingOwnerPlayer() && this.rand.nextInt(60) == 0) {
+            } else if (!this.getIsHunting() && this.isReadyToFollowOwnerPlayer() && !this.getIsFollowingOwnerPlayer() && this.rand.nextInt(150) == 0) {
                 setIsFollowingOwnerPlayer(true);
             }
 
             if (getIsHunting() && ++this.huntingCounter > 50) {
                 setIsHunting(false);
             }
-            if (this.getIsFollowingOwnerPlayer() && ++this.followPlayerCounter > 50) {
+            if (this.getIsFollowingOwnerPlayer() && ++this.followPlayerCounter > 175) {
                 setIsFollowingOwnerPlayer(false);
             }
 

--- a/src/main/java/drzhark/mocreatures/entity/ai/EntityAIFollowOwnerPlayer.java
+++ b/src/main/java/drzhark/mocreatures/entity/ai/EntityAIFollowOwnerPlayer.java
@@ -4,6 +4,7 @@
 package drzhark.mocreatures.entity.ai;
 
 import drzhark.mocreatures.entity.IMoCEntity;
+import drzhark.mocreatures.entity.MoCEntityAnimal;
 import drzhark.mocreatures.entity.tameable.IMoCTameable;
 import net.minecraft.block.material.Material;
 import net.minecraft.block.state.IBlockState;
@@ -50,6 +51,9 @@ public class EntityAIFollowOwnerPlayer extends EntityAIBase {
     @Override
     public boolean shouldExecute() {
         if (((IMoCEntity) this.thePet).getIsSitting()) {
+            return false;
+        }
+        if (!((MoCEntityAnimal) this.thePet).getIsFollowingOwnerPlayer()) {
             return false;
         }
 

--- a/src/main/java/drzhark/mocreatures/entity/ambient/MoCEntityCrab.java
+++ b/src/main/java/drzhark/mocreatures/entity/ambient/MoCEntityCrab.java
@@ -156,6 +156,9 @@ public class MoCEntityCrab extends MoCEntityTameableAnimal {
     }
 
     @Override
+    public boolean isReadyToFollowOwnerPlayer() { return !this.isMovementCeased(); }
+
+    @Override
     protected SoundEvent getDeathSound() {
         return null;
     }
@@ -165,3 +168,4 @@ public class MoCEntityCrab extends MoCEntityTameableAnimal {
         return null;
     }
 }
+

--- a/src/main/java/drzhark/mocreatures/entity/hunter/MoCEntityBear.java
+++ b/src/main/java/drzhark/mocreatures/entity/hunter/MoCEntityBear.java
@@ -309,6 +309,9 @@ public class MoCEntityBear extends MoCEntityTameableAnimal {
         return this.getIsAdult() && !this.isMovementCeased();
     }
 
+    @Override
+    public boolean isReadyToFollowOwnerPlayer() { return !this.isMovementCeased(); }
+
     public boolean getIsStanding() {
         return this.standingCounter != 0;
     }

--- a/src/main/java/drzhark/mocreatures/entity/hunter/MoCEntityBigCat.java
+++ b/src/main/java/drzhark/mocreatures/entity/hunter/MoCEntityBigCat.java
@@ -367,6 +367,9 @@ public class MoCEntityBigCat extends MoCEntityTameableAnimal {
     }
 
     @Override
+    public boolean isReadyToFollowOwnerPlayer() { return !this.isMovementCeased(); }
+
+    @Override
     public void updatePassenger(Entity passenger) {
         double dist = getSizeFactor() * (0.1D);
         double newPosX = this.posX + (dist * Math.sin(this.renderYawOffset / 57.29578F));

--- a/src/main/java/drzhark/mocreatures/entity/hunter/MoCEntityFox.java
+++ b/src/main/java/drzhark/mocreatures/entity/hunter/MoCEntityFox.java
@@ -199,6 +199,9 @@ public class MoCEntityFox extends MoCEntityTameableAnimal {
     }
 
     @Override
+    public boolean isReadyToFollowOwnerPlayer() { return !this.isMovementCeased(); }
+
+    @Override
     public float getSizeFactor() {
         if (getIsAdult()) {
             return 0.9F;

--- a/src/main/java/drzhark/mocreatures/entity/hunter/MoCEntityPetScorpion.java
+++ b/src/main/java/drzhark/mocreatures/entity/hunter/MoCEntityPetScorpion.java
@@ -162,6 +162,9 @@ public class MoCEntityPetScorpion extends MoCEntityTameableAnimal {
     }
 
     @Override
+    public boolean isReadyToFollowOwnerPlayer() { return !this.isMovementCeased(); }
+
+    @Override
     public void setRideable(boolean flag) {
         this.dataManager.set(RIDEABLE, flag);
     }

--- a/src/main/java/drzhark/mocreatures/entity/hunter/MoCEntityRaccoon.java
+++ b/src/main/java/drzhark/mocreatures/entity/hunter/MoCEntityRaccoon.java
@@ -164,6 +164,9 @@ public class MoCEntityRaccoon extends MoCEntityTameableAnimal {
         return this.getIsAdult() && !this.isMovementCeased();
     }
 
+    @Override
+    public boolean isReadyToFollowOwnerPlayer() { return !this.isMovementCeased(); }
+
     public float getEyeHeight() {
         return this.height * 0.86F;
     }

--- a/src/main/java/drzhark/mocreatures/entity/passive/MoCEntityBird.java
+++ b/src/main/java/drzhark/mocreatures/entity/passive/MoCEntityBird.java
@@ -532,4 +532,7 @@ public class MoCEntityBird extends MoCEntityTameableAnimal {
     public float getEyeHeight() {
         return this.height * 0.75F;
     }
+
+    @Override
+    public boolean isReadyToFollowOwnerPlayer() { return !this.isMovementCeased(); }
 }

--- a/src/main/java/drzhark/mocreatures/entity/passive/MoCEntityBunny.java
+++ b/src/main/java/drzhark/mocreatures/entity/passive/MoCEntityBunny.java
@@ -303,4 +303,7 @@ public class MoCEntityBunny extends MoCEntityTameableAnimal {
     public float getEyeHeight() {
         return this.height * 0.675F;
     }
+
+    @Override
+    public boolean isReadyToFollowOwnerPlayer() { return !this.isMovementCeased(); }
 }

--- a/src/main/java/drzhark/mocreatures/entity/passive/MoCEntityTurtle.java
+++ b/src/main/java/drzhark/mocreatures/entity/passive/MoCEntityTurtle.java
@@ -419,4 +419,7 @@ public class MoCEntityTurtle extends MoCEntityTameableAnimal {
     public float getEyeHeight() {
         return this.height * 0.525F;
     }
+
+    @Override
+    public boolean isReadyToFollowOwnerPlayer() { return !this.isMovementCeased(); }
 }


### PR DESCRIPTION
# Issue
- #98

# Questions
1. Please check the chances and duration of the Follow behavior, to see if it is to our liking. Happy to adjust either Occurance Chance or Duration.

# Solution
Add 1/500 chance (same as Hunting chance) to follow owner for mobs that implement `EntityAIFollowOwnerPlayer`, instead of constant repetition of that AI behavior.

Once they are following the player, they will continue to do so for 175 `onLivingUpdate` counts (ticks?), provided that the AI event was not cancelled by one with a higher prioirity.