### PR TITLE
104 - BUGFIX for `Bear` moves around while sitting & BUGFIX for Sitting Babies follow Adults

### DIFF
--- a/src/main/java/drzhark/mocreatures/client/model/MoCModelBear.java
+++ b/src/main/java/drzhark/mocreatures/client/model/MoCModelBear.java
@@ -534,7 +534,7 @@ public class MoCModelBear extends ModelBase {
             this.BLegRR1.render(f5);
             this.BLegRR2.render(f5);
             this.BLegRR3.render(f5);
-        } else if (bearstate == 2) { //sited
+        } else if (bearstate == 2 || bearstate == 3) { //sited
             if (openMouth) {
                 this.CMouthOpen.render(f5);
             } else {
@@ -664,7 +664,7 @@ public class MoCModelBear extends ModelBase {
             this.BLegRL1.rotateAngleX = -0.5235988F + RLegRotX;
             this.BLegRL2.rotateAngleX = RLegRotX;
             this.BLegRL3.rotateAngleX = RLegRotX;
-        } else if (this.bearstate == 2) {
+        } else if (this.bearstate == 2 || this.bearstate == 3) {
             this.CHead.rotateAngleX = 0.1502636F + XAngle;
             this.CHead.rotateAngleY = YAngle;
 

--- a/src/main/java/drzhark/mocreatures/entity/ai/EntityAIFollowAdult.java
+++ b/src/main/java/drzhark/mocreatures/entity/ai/EntityAIFollowAdult.java
@@ -29,6 +29,9 @@ public class EntityAIFollowAdult extends EntityAIBase {
      */
     @Override
     public boolean shouldExecute() {
+        if (((IMoCEntity) this.childAnimal).getIsSitting()) {
+            return false;
+        }
         if ((!(this.childAnimal instanceof IMoCEntity)) || ((IMoCEntity) this.childAnimal).getIsAdult()) {
             return false;
         } else {
@@ -65,6 +68,9 @@ public class EntityAIFollowAdult extends EntityAIBase {
      */
     @Override
     public boolean shouldContinueExecuting() {
+        if (((IMoCEntity) this.childAnimal).getIsSitting()) {
+            return false;
+        }
         if (((IMoCEntity) this.childAnimal).getIsAdult()) {
             return false;
         } else if (!this.parentAnimal.isEntityAlive()) {

--- a/src/main/java/drzhark/mocreatures/entity/hunter/MoCEntityBear.java
+++ b/src/main/java/drzhark/mocreatures/entity/hunter/MoCEntityBear.java
@@ -191,6 +191,7 @@ public class MoCEntityBear extends MoCEntityTameableAnimal {
     @Override
     public void onLivingUpdate() {
         super.onLivingUpdate();
+        System.out.println("BEAR STATE: "+getBearState());
         if (this.mouthCounter > 0 && ++this.mouthCounter > 20) {
             this.mouthCounter = 0;
         }
@@ -323,14 +324,30 @@ public class MoCEntityBear extends MoCEntityTameableAnimal {
         this.standingCounter = 1;
     }
 
+    public void processBearWhipped() {
+        if (!this.isMovementCeased()) {
+            // Set to "SITTING via WHIP"
+            setBearState(3);
+        } else {
+            // Set to "on all fours"
+            setBearState(0);
+        }
+        setIsJumping(false);
+        getNavigator().clearPath();
+        setAttackTarget(null);
+    }
     @Override
     public boolean processInteract(EntityPlayer player, EnumHand hand) {
+        final ItemStack stack = player.getHeldItem(hand);
+        if (!stack.isEmpty() && getIsTamed() && (stack.getItem() == MoCItems.whip)) {
+            this.processBearWhipped();
+            return true;
+        }
         final Boolean tameResult = this.processTameInteract(player, hand);
         if (tameResult != null) {
             return tameResult;
         }
 
-        final ItemStack stack = player.getHeldItem(hand);
         if (!stack.isEmpty() && getIsTamed() && !getIsRideable() && (getAge() > 80)
                 && (stack.getItem() instanceof ItemSaddle || stack.getItem() == MoCItems.horsesaddle)) {
             if (!player.capabilities.isCreativeMode) stack.shrink(1);
@@ -358,19 +375,6 @@ public class MoCEntityBear extends MoCEntityTameableAnimal {
             if (!this.world.isRemote) {
                 player.displayGUIChest(this.localchest);
             }
-            return true;
-        }
-        if (!stack.isEmpty() && getIsTamed() && (stack.getItem() == MoCItems.whip)) {
-            if (!this.isMovementCeased()) {
-                // Set to "SITTING via WHIP"
-                setBearState(3);
-            } else {
-                // Set to "on all fours"
-                setBearState(0);
-            }
-            setIsJumping(false);
-            getNavigator().clearPath();
-            setAttackTarget(null);
             return true;
         }
 

--- a/src/main/java/drzhark/mocreatures/entity/hunter/MoCEntityBear.java
+++ b/src/main/java/drzhark/mocreatures/entity/hunter/MoCEntityBear.java
@@ -109,6 +109,10 @@ public class MoCEntityBear extends MoCEntityTameableAnimal {
     }
 
     @Override
+    public boolean getIsSitting() {
+        return this.isMovementCeased();
+    }
+    @Override
     public boolean getIsRideable() {
         return this.dataManager.get(RIDEABLE);
     }
@@ -191,7 +195,6 @@ public class MoCEntityBear extends MoCEntityTameableAnimal {
     @Override
     public void onLivingUpdate() {
         super.onLivingUpdate();
-        System.out.println("BEAR STATE: "+getBearState());
         if (this.mouthCounter > 0 && ++this.mouthCounter > 20) {
             this.mouthCounter = 0;
         }

--- a/src/main/java/drzhark/mocreatures/entity/hunter/MoCEntityBear.java
+++ b/src/main/java/drzhark/mocreatures/entity/hunter/MoCEntityBear.java
@@ -197,7 +197,7 @@ public class MoCEntityBear extends MoCEntityTameableAnimal {
         if (this.attackCounter > 0 && ++this.attackCounter > 9) {
             this.attackCounter = 0;
         }
-        if (!this.world.isRemote && !getIsAdult() && getAge() < 80 && (this.rand.nextInt(300) == 0)) {
+        if (!this.world.isRemote && getBearState() != 3 && !getIsAdult() && getAge() < 80 && (this.rand.nextInt(300) == 0)) {
             setBearState(2); // randomly perform an idle sit
         }
         /*
@@ -209,7 +209,7 @@ public class MoCEntityBear extends MoCEntityTameableAnimal {
         if (!this.world.isRemote && getBearState() == 2 && !this.getNavigator().noPath()) {
             setBearState(0);
         }
-        if (!this.world.isRemote && this.standingCounter > 0 && ++this.standingCounter > 100) {
+        if (!this.world.isRemote && this.standingCounter > 0 && ++this.standingCounter > 100 && getBearState() != 3) {
             this.standingCounter = 0;
             setBearState(0);
         }

--- a/src/main/java/drzhark/mocreatures/entity/hunter/MoCEntityBlackBear.java
+++ b/src/main/java/drzhark/mocreatures/entity/hunter/MoCEntityBlackBear.java
@@ -99,11 +99,7 @@ public class MoCEntityBlackBear extends MoCEntityBear {
             return true;
         }
         if (!stack.isEmpty() && getIsTamed() && (stack.getItem() == MoCItems.whip)) {
-            if (getBearState() == 0) {
-                setBearState(2);
-            } else {
-                setBearState(0);
-            }
+            this.processBearWhipped();
             return true;
         }
         if (this.getIsRideable() && this.getIsAdult() && (!this.getIsChested() || !player.isSneaking()) && !this.isBeingRidden()) {

--- a/src/main/java/drzhark/mocreatures/entity/hunter/MoCEntityGrizzlyBear.java
+++ b/src/main/java/drzhark/mocreatures/entity/hunter/MoCEntityGrizzlyBear.java
@@ -97,11 +97,7 @@ public class MoCEntityGrizzlyBear extends MoCEntityBear {
             return true;
         }
         if (!stack.isEmpty() && getIsTamed() && (stack.getItem() == MoCItems.whip)) {
-            if (getBearState() == 0) {
-                setBearState(2);
-            } else {
-                setBearState(0);
-            }
+            this.processBearWhipped();
             return true;
         }
         if (this.getIsRideable() && this.getIsAdult() && (!this.getIsChested() || !player.isSneaking()) && !this.isBeingRidden()) {

--- a/src/main/java/drzhark/mocreatures/entity/hunter/MoCEntityPolarBear.java
+++ b/src/main/java/drzhark/mocreatures/entity/hunter/MoCEntityPolarBear.java
@@ -98,11 +98,7 @@ public class MoCEntityPolarBear extends MoCEntityBear {
             return true;
         }
         if (!stack.isEmpty() && getIsTamed() && (stack.getItem() == MoCItems.whip)) {
-            if (getBearState() == 0) {
-                setBearState(2);
-            } else {
-                setBearState(0);
-            }
+            this.processBearWhipped();
             return true;
         }
         if (this.getIsRideable() && this.getIsAdult() && (!this.getIsChested() || !player.isSneaking()) && !this.isBeingRidden()) {

--- a/src/main/java/drzhark/mocreatures/entity/neutral/MoCEntityPandaBear.java
+++ b/src/main/java/drzhark/mocreatures/entity/neutral/MoCEntityPandaBear.java
@@ -107,12 +107,8 @@ public class MoCEntityPandaBear extends MoCEntityBear {
 
             return true;
         }
-        if (!stack.isEmpty() && getIsTamed() && stack.getItem() == MoCItems.whip) {
-            if (getBearState() == 0) {
-                setBearState(2);
-            } else {
-                setBearState(0);
-            }
+        if (!stack.isEmpty() && getIsTamed() && (stack.getItem() == MoCItems.whip)) {
+            this.processBearWhipped();
             return true;
         }
         if (this.getIsRideable() && this.getIsAdult() && (!this.getIsChested() || !player.isSneaking()) && !this.isBeingRidden()) {
@@ -143,7 +139,7 @@ public class MoCEntityPandaBear extends MoCEntityBear {
         /*
          * panda bears and cubs will sit down sometimes
          */
-        if (!this.world.isRemote && !getIsTamed() && this.rand.nextInt(300) == 0) {
+        if (!this.world.isRemote && getBearState() != 3 && !getIsTamed() && this.rand.nextInt(300) == 0) {
             setBearState(2);
         }
     }

--- a/src/main/java/drzhark/mocreatures/item/MoCItemWhip.java
+++ b/src/main/java/drzhark/mocreatures/item/MoCItemWhip.java
@@ -140,18 +140,6 @@ public class MoCItemWhip extends MoCItem {
                         entityelephant.sprintCounter = 1;
                     }
                 }
-
-                if (entity instanceof MoCEntityBear) {
-                    MoCEntityBear entitybear = (MoCEntityBear) entity;
-
-                    if (entitybear.getIsTamed()) {
-                        if (entitybear.getBearState() == 0) {
-                            entitybear.setBearState(2);
-                        } else {
-                            entitybear.setBearState(0);
-                        }
-                    }
-                }
             }
             return EnumActionResult.SUCCESS;
         }


### PR DESCRIPTION
# Issue
- #104 

# Solution
Update Bear states, split "Sitting" state into two states-- 
one that is the idle bear sitting, and the other that is invoked by the player whipping the bear.

Also had to go through `Bear` subclasses like `GrizzlyBear`, which had "whip" setting the state to "Sitting Idle".